### PR TITLE
Speedup test_models

### DIFF
--- a/src/python/examples/cooling_cell.py
+++ b/src/python/examples/cooling_cell.py
@@ -35,17 +35,18 @@ from pygrackle.utilities.model_tests import \
 
 output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 1:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_chemistry, input_set = get_model_set(
             output_name, par_index, input_index)
-        for var, val in input_set.items():
-            globals()[var] = val
+        metallicity = input_set["metallicity"]
+        redshift = input_set["redshift"]
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
 
@@ -111,3 +112,7 @@ if __name__ == "__main__":
     # save data arrays as a yt dataset
     yt.save_as_dataset({}, f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/python/examples/cooling_rate.py
+++ b/src/python/examples/cooling_rate.py
@@ -31,17 +31,20 @@ from pygrackle.utilities.model_tests import \
 
 output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 0:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_chemistry, input_set = get_model_set(
             output_name, par_index, input_index)
-        for var, val in input_set.items():
-            globals()[var] = val
+        metallicity = input_set["metallicity"]
+        redshift = input_set["redshift"]
+        specific_heating_rate = input_set["specific_heating_rate"]
+        volumetric_heating_rate = input_set["volumetric_heating_rate"]
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
 
@@ -106,3 +109,7 @@ if __name__ == "__main__":
     pyplot.savefig(f"{output_name}.png")
     yt.save_as_dataset({}, filename=f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/examples/freefall.py
+++ b/src/python/examples/freefall.py
@@ -32,17 +32,17 @@ from pygrackle.utilities.model_tests import \
 
 output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 
-if __name__=="__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 0:
+        par_index = int(args[0])
+        input_index = int(args[1])
         my_chemistry, input_set = get_model_set(
             output_name, par_index, input_index)
-        for var, val in input_set.items():
-            globals()[var] = val
+        metallicity = input_set["metallicity"]
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
 
@@ -131,3 +131,7 @@ if __name__=="__main__":
     # save data arrays as a yt dataset
     yt.save_as_dataset({}, f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/examples/yt_grackle.py
+++ b/src/python/examples/yt_grackle.py
@@ -24,13 +24,14 @@ output_name = os.path.basename(__file__[:-3]) # strip off ".py"
 DS_NAME = "IsolatedGalaxy/galaxy0030/galaxy0030"
 ds_path = os.path.join(os.environ.get('YT_DATA_DIR', default='.'), DS_NAME)
 
-if __name__ == "__main__":
+def main(args=None, output_name=output_name):
+    args = sys.argv[1:] if args is None else args
     # If we are running the script through the testing framework,
     # then we will pass in two integers corresponding to the sets
     # of parameters and inputs.
-    if len(sys.argv) > 1:
-        par_index = int(sys.argv[1])
-        input_index = int(sys.argv[2])
+    if len(args) > 1:
+        par_index = int(args[0])
+        input_index = int(args[1])
         output_name = f"{output_name}_{par_index}_{input_index}"
         extra_attrs = {"format_version": model_test_format_version}
 
@@ -70,3 +71,7 @@ if __name__ == "__main__":
     data = {field: sp[field] for field in fields}
     yt.save_as_dataset(ds, filename=f"{output_name}.h5",
                        data=data, extra_attrs=extra_attrs)
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/python/tests/test_models.py
+++ b/src/python/tests/test_models.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import pytest
 import sys
@@ -10,7 +11,18 @@ from pygrackle.utilities.testing import run_command
 
 from testing_common import grackle_python_dir
 
-python_example_dir = os.path.join(grackle_python_dir, "examples")
+sys.path.append(os.path.join(grackle_python_dir, "examples"))
+from cooling_cell import main as _cooling_cell_main
+from cooling_rate import main as _cooling_rate_main
+from freefall import main as _freefall_main
+from yt_grackle import main as _yt_grackle_main
+
+model_fns = {
+    "cooling_cell" : _cooling_cell_main,
+    "cooling_rate" : _cooling_rate_main,
+    "freefall" : _freefall_main,
+    "yt_grackle" : _yt_grackle_main
+}
 
 # collect all of the python-examples and various model configurations into
 # a list of tuples
@@ -39,13 +51,17 @@ def test_model(answertestspec, tmp_path, model_name, par_index, input_index):
     if (model_name == "yt_grackle") and ("YT_DATA_DIR" not in os.environ):
         pytest.skip("YT_DATA_DIR env variable isn't defined")
 
-    script_path = os.path.join(python_example_dir, f"{model_name}.py")
-    command = f"{sys.executable} {script_path} {par_index} {input_index}"
+    # TODO: figure out how to instruct the examples where to store the results as a
+    #       function argument (so we can stop using os.chdir)
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        return_val = model_fns[model_name](args=[str(par_index), str(input_index)])
+    finally:
+        os.chdir(original_cwd)
+    assert return_val == 0, "example didn't complete succesfully"
 
     if True:
-        rval = run_command(command, timeout=60, cwd=tmp_path)
-        assert rval, "example didn't complete succesfully"
-
         output_basename = f"{model_name}_{par_index}_{input_index}.h5"
         output_file = os.path.join(str(tmp_path), output_basename)
         answer_path = os.path.join(answertestspec.answer_dir, output_basename)


### PR DESCRIPTION
This PR is a prototype for speeding up `test_models.py` (I'll move it to the main repository once the circleci credits are no longer an issue).

---------

The idea here is to stop using subprocess.run. On my machine, the time it takes to run `test_model.py` decreases by 25%.

I also have some other ideas for speedup.